### PR TITLE
Add support for Kotlin 1.6.0 And bump version to 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The plugin adds `readResolve` method for every object which either:
 
 // plugins dsl
 plugins {
-  id "me.shika.kotlin-object-java-serialization" version "1.1.0"
+  id "me.shika.kotlin-object-java-serialization" version "1.2.0"
 }
 
 // or else
@@ -25,7 +25,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath "me.shika:kotlin-object-java-serialization:1.1.0"
+    classpath "me.shika:kotlin-object-java-serialization:1.2.0"
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '1.5.21'
+    id 'org.jetbrains.kotlin.jvm' version '1.6.0'
 }
 
 sourceCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -13,5 +13,5 @@ allprojects {
     }
 
     group 'me.shika'
-    version '1.1.0'
+    version '1.2.0'
 }

--- a/gradle-plugin/src/main/kotlin/me/shika/ObjectSerializationSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/me/shika/ObjectSerializationSubplugin.kt
@@ -1,30 +1,25 @@
 package me.shika
 
-import org.gradle.api.Project
-import org.gradle.api.tasks.compile.AbstractCompile
-import org.jetbrains.kotlin.gradle.dsl.KotlinCommonOptions
+import org.gradle.api.internal.provider.DefaultListProperty
+import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
-import org.jetbrains.kotlin.gradle.plugin.KotlinGradleSubplugin
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
 import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
 import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 
-class ObjectSerializationSubplugin: KotlinGradleSubplugin<AbstractCompile> {
-    override fun apply(
-        project: Project,
-        kotlinCompile: AbstractCompile,
-        javaCompile: AbstractCompile?,
-        variantData: Any?,
-        androidProjectHandler: Any?,
-        kotlinCompilation: KotlinCompilation<KotlinCommonOptions>?
-    ): List<SubpluginOption> {
+class ObjectSerializationSubplugin: KotlinCompilerPluginSupportPlugin {
+    override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
+        val project = kotlinCompilation.target.project
         val extension = project.extensions.findByType(ObjectSerializationExtension::class.java) ?: ObjectSerializationExtension()
 
-        return listOf(
-            SubpluginOption(
-                key = "enabled",
-                value = extension.enabled.toString()
+        return DefaultListProperty(SubpluginOption::class.java).apply {
+            add(
+                SubpluginOption(
+                    key = "enabled",
+                    value = extension.enabled.toString()
+                )
             )
-        )
+        }
     }
 
     override fun getCompilerPluginId(): String = "object-serialization-fix"
@@ -36,6 +31,6 @@ class ObjectSerializationSubplugin: KotlinGradleSubplugin<AbstractCompile> {
             version = "1.1.0"
         )
 
-    override fun isApplicable(project: Project, task: AbstractCompile): Boolean =
-        project.plugins.hasPlugin(ObjectSerializationPlugin::class.java)
+    override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean =
+        kotlinCompilation.target.project.plugins.hasPlugin(ObjectSerializationPlugin::class.java)
 }

--- a/gradle-plugin/src/main/kotlin/me/shika/ObjectSerializationSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/me/shika/ObjectSerializationSubplugin.kt
@@ -28,7 +28,7 @@ class ObjectSerializationSubplugin: KotlinCompilerPluginSupportPlugin {
         SubpluginArtifact(
             groupId = "me.shika",
             artifactId = "kotlin-object-java-serialization",
-            version = "1.1.0"
+            version = "1.2.0"
         )
 
     override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean =


### PR DESCRIPTION
According to the [Kotlin 1.6.0 release notes](https://kotlinlang.org/docs/whatsnew16.html#kotlin-gradle-plugin):
> In Kotlin 1.6.0, we changed the deprecation level of the `KotlinGradleSubplugin` class to 'ERROR'. This class was used for writing compiler plugins. In the following releases, we'll remove this class. Use the class `KotlinCompilerPluginSupportPlugin` instead.