### PR TITLE
Upgrade to Kotlin 2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '2.0.0'
+    id 'org.jetbrains.kotlin.jvm' version '2.1.0'
 }
 
 allprojects {

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -26,5 +26,5 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     implementation "org.jetbrains.kotlin:kotlin-gradle-plugin-api"
 
-    embedded project(':kotlin-plugin')
+//    embedded project(':kotlin-plugin')
 }

--- a/kotlin-plugin/src/test/kotlin/me/shika/ObjectSerializationFixTest.kt
+++ b/kotlin-plugin/src/test/kotlin/me/shika/ObjectSerializationFixTest.kt
@@ -14,7 +14,7 @@ import java.lang.reflect.Method
 @RunWith(Parameterized::class)
 class ObjectSerializationFixTest(enableFir: Boolean) {
     companion object {
-        @Parameters(name = "FIR: {1}")
+        @Parameters(name = "FIR: {0}")
         @JvmStatic
         fun data() = arrayOf(false, true)
     }


### PR DESCRIPTION
@ShikaSD Thank you for reviewing my last PR! I'm glad you were able to publish a version for kotlin 2.0 because kotlin 2.1 comes with additional breaking changes.

In particular, the signature of `IrValueParameter.copyTo` changed from 2.0 -> 2.1. It no longer takes a parameter `index: Int = this.index`. We call this function in `ObjectSerializationIRGeneration.kt` line 43:

```kotlin
            // Ensure it is not static
            function.dispatchReceiverParameter = cls.thisReceiver?.copyTo(function)
```

Because the parameter has a default value, _there is no code change_, but the underlying bytecode is no longer compatible. Therefore, all we have to do is update the kotlin version and recompile the bytecode.
